### PR TITLE
Comandos para exibir o cardápio dos bandejões do Butantã

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -57,15 +57,13 @@ function cardapioButanta(time) {
 
     return text;
 }
-
-bot.onText(/\/almocoButanta/, (msg) => {
+bot.onText(/\/almoco_butanta/, (msg) => {
     let text = cardapioButanta(0);
 
     let options = {parse_mode: "Markdown"};
     bot.sendMessage(msg.chat.id, text, options).catch(handleError);
 });
-
-bot.onText(/\/jantaButanta/, (msg) => {
+bot.onText(/\/janta_butanta/, (msg) => {
     let text = cardapioButanta(1);
 
     let options = {parse_mode: "Markdown"};

--- a/src/bot.js
+++ b/src/bot.js
@@ -34,9 +34,42 @@ notifications.setup((text, id) => {
 });
 
 //ao receber qualquer mensagem, printar o menu inicial
-bot.on('message', (msg) => {
+bot.on('/start', (msg) => {
     comm = mensagens.prepare(mensagens.INITIAL);
     bot.sendMessage(msg.chat.id, comm.text, comm.opts).catch(handleError);
+});
+
+function cardapioButanta(time) {
+    const BUTANTA = ['CENTRAL', 'FISICA', 'QUIMICA', 'PREFEITURA'];
+
+    let menus = {};
+    let bandexes = cardapios.getBandexList();
+    bandexes.forEach(band => {
+        menus[band.code] = mensagens.getDigestEntry(cardapios.fetch(band.code, time));
+    });
+
+    let text = mensagens.getDigestTitle(time);
+    for (let item of bandexes) {
+        if (BUTANTA.includes(item.code)) {
+            text += menus[item.code];
+        }
+    }
+
+    return text;
+}
+
+bot.onText(/\/almocoButanta/, (msg) => {
+    let text = cardapioButanta(0);
+
+    let options = {parse_mode: "Markdown"};
+    bot.sendMessage(msg.chat.id, text, options).catch(handleError);
+});
+
+bot.onText(/\/jantaButanta/, (msg) => {
+    let text = cardapioButanta(1);
+
+    let options = {parse_mode: "Markdown"};
+    bot.sendMessage(msg.chat.id, text, options).catch(handleError);
 });
 
 //interpretar respostas do teclado interativo


### PR DESCRIPTION
Quando vamos comparar o cardápio dos bandejões do Butantã, temos que ir e voltar no menu várias vezes. Além disso, cada ação no menu faz uma requisição no servidor do bot, portanto uma conexão instável pode causar uma experiência ruim.

Ficaria mais fácil para comparar entre os quatro bandecos se o conteúdo fosse impresso de uma vez só. Esse PR inclui dois comandos, o `/almoco_butanta` e o `/janta_butanta` que retorna os cardápios. Essa funcionalidade é particularmente útil quando o bot está num grupo, já que ações no menu realizadas por alguém não são visíveis ao outros membros do grupo.

Para adicionar os novos comandos, foi necessário alterar o comportamento do menu inicial, que era disparado ao receber qualquer mensagem. Agora, ele só é disparado ao receber a mensagem `/start`.

O bot de teste é o http://t.me/bandextestebot, porém só vai estar no ar até eu desligar meu computador. 😄

<img width="590" alt="image" src="https://user-images.githubusercontent.com/38678447/41620596-8e770bf6-73e0-11e8-85e1-4c9f45c92c0a.png">